### PR TITLE
Refactoring: gRPC server refined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ name = "orderbook-aggregator"
 version = "0.1.0"
 edition = "2021"
 
-[[bin]] # Bin to run the HelloWorld gRPC server
+[[bin]]
 name = "server"
 path = "src/server.rs"
 
-[[bin]] # Bin to run the HelloWorld gRPC client
+[[bin]]
 name = "client"
 path = "src/client.rs"
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,7 @@
-use tokio::sync::mpsc;
+use std::sync::Arc;
+
+use tokio::sync::mpsc::{self, Sender};
+use tokio::sync::Mutex;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -10,38 +13,7 @@ pub mod orderbook {
 }
 
 struct OrderbookAggregatorService {
-    // TODO:
-    // here we can store stream reciever for data from the aggregator
-    // then we will read it from book_summary and send values to the client
-}
-
-fn demo_summary_generator(tx: mpsc::Sender<Result<Summary, Status>>) {
-    tokio::spawn(async move {
-        let mut i = 0;
-
-        loop {
-            let spread = i as f64;
-            let summary = Summary {
-                spread: i as f64,
-                bids: vec![Level {
-                    exchange: "binance".to_string(),
-                    price: 1.0 - (spread / 2.0),
-                    amount: 1.0,
-                }],
-                asks: vec![Level {
-                    exchange: "bitstamp".to_string(),
-                    price: 1.0 + (spread / 2.0),
-                    amount: 1.0,
-                }],
-            };
-
-            tx.send(Ok(summary)).await.unwrap();
-            println!("Sent summary. Spread: {}", spread);
-
-            i += 1;
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        }
-    });
+    clients: Arc<Mutex<Vec<Sender<Result<Summary, Status>>>>>,
 }
 
 #[tonic::async_trait]
@@ -54,7 +26,10 @@ impl OrderbookAggregator for OrderbookAggregatorService {
     ) -> Result<Response<Self::BookSummaryStream>, Status> {
         let (tx, rx) = mpsc::channel(1);
 
-        demo_summary_generator(tx);
+        let mut clients = self.clients.lock().await;
+        clients.push(tx.clone());
+        println!("New client connected. {} clients connected", clients.len());
+        drop(clients);
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
@@ -62,9 +37,67 @@ impl OrderbookAggregator for OrderbookAggregatorService {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "[::1]:10000".parse().unwrap();
+    let addr = "[::1]:10000".parse()?;
 
-    let orderbook_aggregator = OrderbookAggregatorService {};
+    let clients: Arc<Mutex<Vec<Sender<Result<Summary, Status>>>>> = Arc::new(Mutex::new(vec![]));
+
+    let _demo_server_thread = {
+        let clients = clients.clone();
+        tokio::spawn(async move {
+            let mut i = 0;
+            let clients = clients.clone();
+
+            loop {
+                let spread = i as f64;
+                let summary = Summary {
+                    spread: i as f64,
+                    bids: vec![Level {
+                        exchange: "binance".to_string(),
+                        price: 1.0 - (spread / 2.0),
+                        amount: 1.0,
+                    }],
+                    asks: vec![Level {
+                        exchange: "bitstamp".to_string(),
+                        price: 1.0 + (spread / 2.0),
+                        amount: 1.0,
+                    }],
+                };
+                println!("Current spread: {}", spread);
+
+                let mut clients = clients.lock().await;
+
+                let mut client_index = 0;
+
+                while client_index < clients.len() {
+                    let client = &clients[client_index];
+
+                    if client.is_closed() {
+                        clients.remove(client_index);
+
+                        println!(
+                            "Client #{} disconnected. Clients left: {}",
+                            client_index,
+                            clients.len()
+                        );
+
+                        continue;
+                    }
+
+                    client.send(Ok(summary.clone())).await.expect(
+                        format!("Failed to send summary to client #{}", client_index).as_str(),
+                    );
+                    println!("Sent summary to client #{}", client_index);
+
+                    client_index += 1;
+                }
+
+                i += 1;
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+        })
+    };
+
+    let orderbook_aggregator = OrderbookAggregatorService { clients };
 
     let svc = OrderbookAggregatorServer::new(orderbook_aggregator);
 


### PR DESCRIPTION
In the previous implementation I spawned a new thread for each client. 
I decided that it would be more efficient if I created a new channel for each client, but not a thread.
We can bypass the array of tx of clients and send messages to them in one thread.