### PR TITLE
Perfomance improve: `tokio::mpsc` replaced with `flume`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin 0.9.4",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,8 +330,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -558,6 +573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,11 +618,11 @@ dependencies = [
 name = "orderbook-aggregator-server"
 version = "0.1.0"
 dependencies = [
+ "flume",
  "prost",
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "tonic",
  "tonic-build",
  "tungstenite",
@@ -837,7 +861,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -1039,6 +1063,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strum"

--- a/run-client.sh
+++ b/run-client.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+(
+    cargo run --bin orderbook-aggregator-client --release
+)

--- a/run-server.sh
+++ b/run-server.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+(
+    cargo run --bin orderbook-aggregator-server --release
+)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+flume = "0.10.14"
 prost = "0.11.2"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1.11"
 tonic = "0.8.2"
 tungstenite = { version = "0.17.3", features = ["rustls-tls-native-roots"] }
 url = "2.3.1"

--- a/server/src/data_sources/mod.rs
+++ b/server/src/data_sources/mod.rs
@@ -1,5 +1,3 @@
-use tokio::sync::mpsc::{self, Receiver};
-
 // Unified output data format
 pub mod output_data_format;
 use output_data_format::ExchangeOrderbookData;
@@ -8,8 +6,8 @@ use output_data_format::ExchangeOrderbookData;
 mod binance;
 mod bitstamp;
 
-pub fn get_data_rx(symbol: String, depth: u16) -> Receiver<ExchangeOrderbookData> {
-    let (tx, rx) = mpsc::channel::<ExchangeOrderbookData>(1);
+pub fn get_data_rx(symbol: String, depth: u16) -> flume::Receiver<ExchangeOrderbookData> {
+    let (tx, rx) = flume::bounded::<ExchangeOrderbookData>(0);
 
     binance::spawn_thread(symbol.clone(), depth, tx.clone());
 

--- a/server/src/data_sources/output_data_format.rs
+++ b/server/src/data_sources/output_data_format.rs
@@ -50,27 +50,11 @@ impl From<BinanceApiOrderBookMessage> for ExchangeOrderbookData {
     fn from(binance_orderbook_message: BinanceApiOrderBookMessage) -> Self {
         let exchange = "binance".to_string();
 
-        let asks = binance_orderbook_message
-            .asks
-            .iter()
-            .map(|(price, amount)| {
-                (
-                    price.parse::<f64>().unwrap(),
-                    amount.parse::<f64>().unwrap(),
-                )
-            })
-            .collect();
+        let asks = parse_price_amount_tuples(&binance_orderbook_message.asks)
+            .expect("Failed to parse Binance asks");
 
-        let bids = binance_orderbook_message
-            .bids
-            .iter()
-            .map(|(price, amount)| {
-                (
-                    price.parse::<f64>().unwrap(),
-                    amount.parse::<f64>().unwrap(),
-                )
-            })
-            .collect();
+        let bids = parse_price_amount_tuples(&binance_orderbook_message.bids)
+            .expect("Failed to parse Binance bids");
 
         Self::new(exchange, asks, bids)
     }
@@ -80,31 +64,29 @@ impl From<BitstampApiOrderBookData> for ExchangeOrderbookData {
     fn from(bitstamp_orderbook_message: BitstampApiOrderBookData) -> Self {
         let exchange = "bitstamp".to_string();
 
-        let asks = bitstamp_orderbook_message
-            .asks
-            .iter()
-            .map(|(price, amount)| {
-                (
-                    price.parse::<f64>().unwrap(),
-                    amount.parse::<f64>().unwrap(),
-                )
-            })
-            .collect();
+        let asks = parse_price_amount_tuples(&bitstamp_orderbook_message.asks)
+            .expect("Failed to parse Bitstamp asks");
 
-        let bids = bitstamp_orderbook_message
-            .bids
-            .iter()
-            .map(|(price, amount)| {
-                (
-                    price.parse::<f64>().unwrap(),
-                    amount.parse::<f64>().unwrap(),
-                )
-            })
-            .collect();
+        let bids = parse_price_amount_tuples(&bitstamp_orderbook_message.bids)
+            .expect("Failed to parse Bitstamp bids");
 
         let timestamp_in_seconds: u64 = bitstamp_orderbook_message.timestamp.parse().unwrap();
         let timestamp = timestamp_in_seconds * 1000;
 
         Self::new_with_timestamp(exchange, asks, bids, timestamp)
     }
+}
+
+fn parse_price_amount_tuples(
+    vec: &Vec<(String, String)>,
+) -> Result<Vec<(f64, f64)>, Box<dyn std::error::Error>> {
+    let mut result = Vec::new();
+
+    for tuple in vec {
+        let price = tuple.0.parse::<f64>()?;
+        let amount = tuple.1.parse::<f64>()?;
+        result.push((price, amount));
+    }
+
+    Ok(result)
 }

--- a/server/src/helpers.rs
+++ b/server/src/helpers.rs
@@ -10,10 +10,7 @@ where
     <T as FromStr>::Err: Debug,
 {
     let value = match env::var(var_name) {
-        Ok(value) => {
-            let value = value.parse::<T>().unwrap_or(default);
-            value
-        }
+        Ok(value) => value.parse::<T>().unwrap_or(default),
         Err(_) => default,
     };
 

--- a/server/src/summary/calculate.rs
+++ b/server/src/summary/calculate.rs
@@ -22,6 +22,8 @@ pub fn calculate_summary(
             .as_millis();
         let data_age = current_timestamp as u64 - orderbook.timestamp;
 
+        // println!("[DEBUG] {} data age: {}; ", exchange, data_age);
+
         if data_age > data_lifetime_ms {
             // Data is too old, skip it
             continue;

--- a/server/src/summary/calculate.rs
+++ b/server/src/summary/calculate.rs
@@ -6,7 +6,6 @@ use std::{
 use crate::api::orderbook::{Level, Summary};
 use crate::data_sources::output_data_format::ExchangeOrderbookData;
 
-// TODO: measure calculation time
 pub fn calculate_summary(
     orderbook_data: HashMap<String, ExchangeOrderbookData>,
     depth: u16,

--- a/server/src/summary/calculate.rs
+++ b/server/src/summary/calculate.rs
@@ -54,16 +54,16 @@ pub fn calculate_summary(
 
     // sort bids and asks by price and amount
     bids.sort_by(|a, b| {
-        a.price
-            .partial_cmp(&b.price)
+        b.price
+            .partial_cmp(&a.price)
             .unwrap()
-            .then(a.amount.partial_cmp(&b.amount).unwrap())
+            .then(b.amount.partial_cmp(&a.amount).unwrap())
     });
     asks.sort_by(|a, b| {
         a.price
             .partial_cmp(&b.price)
             .unwrap()
-            .then(a.amount.partial_cmp(&b.amount).unwrap())
+            .then(b.amount.partial_cmp(&a.amount).unwrap())
     });
 
     // Select only first `depth` levels

--- a/server/src/summary/mod.rs
+++ b/server/src/summary/mod.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use tokio::sync::mpsc::{self, Receiver};
-
 use crate::api::orderbook::Summary;
 use crate::data_sources::output_data_format::ExchangeOrderbookData;
 
@@ -9,23 +7,26 @@ mod calculate;
 use calculate::calculate_summary;
 
 pub fn get_summary_rx(
-    mut data_rx: Receiver<ExchangeOrderbookData>,
+    data_rx: flume::Receiver<ExchangeOrderbookData>,
     depth: u16,
     data_lifetime_ms: u64,
-) -> Receiver<Summary> {
-    let (tx, rx) = mpsc::channel::<Summary>(1);
+) -> flume::Receiver<Summary> {
+    let (tx, rx) = flume::bounded::<Summary>(0);
 
     tokio::spawn(async move {
         let mut orderbook_data: HashMap<String, ExchangeOrderbookData> = HashMap::new();
 
-        while let Some(data) = data_rx.recv().await {
+        let mut iter = data_rx.into_iter();
+        while let Some(data) = iter.next() {
             orderbook_data.insert(data.exchange.clone(), data);
 
             let summary = calculate_summary(orderbook_data.clone(), depth, data_lifetime_ms);
 
             if let Some(summary) = summary {
-                println!("Summary calculated. Spread: {}", summary.spread);
-                tx.send(summary).await.expect("Failed to send summary");
+                // println!("Summary calculated. Spread: {}", summary.spread);
+                tx.send_async(summary)
+                    .await
+                    .expect("Failed to send summary");
             } else {
                 // if all data is too old, or there is not enough data
                 println!("Failed to calculate summary");


### PR DESCRIPTION
The reasons for choosing [flume](https://docs.rs/flume/latest/flume/) over [tokio::mpsc](https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/index.html):
1. Faster
2. Supports bounded channel with capacity 0.

The [kanal](https://docs.rs/kanal/0.1.0-pre7/kanal/) crate was also tested, and it also showed good results, but unlike [flume](https://docs.rs/flume/latest/flume/) and [tokio::mpsc](https://docs.rs/tokio/0.1.22/tokio/sync/mpsc/index.html) it does not implement [trait Stream](https://docs.rs/futures/0.2.0/futures/stream/trait.Stream.html), so it cannot be used for gRPC stream.

For the same reason [crossbeam_channel](https://docs.rs/crossbeam-channel/latest/crossbeam_channel/) was not considered.