### PR TITLE
FIFO replaced with LIFO

### DIFF
--- a/server/src/data_sources/mod.rs
+++ b/server/src/data_sources/mod.rs
@@ -7,7 +7,7 @@ mod binance;
 mod bitstamp;
 
 pub fn get_data_rx(symbol: String, depth: u16) -> flume::Receiver<ExchangeOrderbookData> {
-    let (tx, rx) = flume::bounded::<ExchangeOrderbookData>(0);
+    let (tx, rx) = flume::bounded::<ExchangeOrderbookData>(10);
 
     binance::spawn_thread(symbol.clone(), depth, tx.clone());
 


### PR DESCRIPTION
Since this data has a very short lifespan, it makes no sense to pass it all and in chronological order. It is much more important to give the most recent data as soon as possible, so iterations across channels have been replaced by draining and retrieving only the last message in a channel.