### PR TITLE
Bugfix: LIFO for ExchangeOrderbookDataRx reverted

### DIFF
--- a/server/src/summary/mod.rs
+++ b/server/src/summary/mod.rs
@@ -18,11 +18,14 @@ pub fn get_summary_rx(
 
         while !data_rx.is_disconnected() {
             let data_rx_drain = data_rx.drain();
-            let data = data_rx_drain.last();
+            let mut need_to_recalculate_summary = false;
 
-            if let Some(data) = data {
+            for data in data_rx_drain {
                 orderbook_data.insert(data.exchange.clone(), data);
+                need_to_recalculate_summary = true;
+            }
 
+            if need_to_recalculate_summary {
                 let summary = calculate_summary(orderbook_data.clone(), depth, data_lifetime_ms);
 
                 if let Some(summary) = summary {


### PR DESCRIPTION
In [pull request #16](https://github.com/torcoste/orderbook-aggregator/pull/16) the `data` and `summary` channels reading model was changed from FIFO to LIFO.

However, I have noticed that it only makes sense to use LIFO for the `summary` channel, since it is more important to pass the most relevant value as soon as possible.

However, the channel `data` receives messages from different exchanges simultaneously in different threads, and when reading only the last message, there is a possibility that the data coming from one of the exchanges can simply be ignored.

So I changed the reading strategy for this channel. We take all the values that are in the channel (using `.drain()`) and update the HashMap from which the summary is calculated later. If the channel contained at least one message, we recalculate the summary, but if there were 5 messages, we put all the changes into the HashMap and then also recalculate the summary **only once**. This allows us to avoid wasting time calculating the summary for old data when there is more recent data.